### PR TITLE
Move decoding to Web Worker

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,15 @@
+{
+	"printWidth": 80,
+	"tabWidth": 2,
+	"useTabs": false,
+	"semi": true,
+	"singleQuote": false,
+	"jsxSingleQuote": false,
+	"trailingComma": "all",
+	"bracketSpacing": true,
+	"bracketSameLine": false,
+	"arrowParens": "always",
+	"endOfLine": "lf",
+	"jsxBracketSameLine": false,
+	"quoteProps": "as-needed"
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,11 +1,21 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import "./App.css";
-import { decode } from "sii-decode-rs";
+import DecodeWorker from "./decode.worker?worker";
+import type { DecodeResponse } from "./decode.worker";
 
 function App() {
   const [file, setFile] = useState<File | null>(null);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const downloadRef = useRef<HTMLAnchorElement>(null);
+  const workerRef = useRef<Worker | null>(null);
+
+  // Initialize worker
+  useEffect(() => {
+    workerRef.current = new DecodeWorker();
+    return () => {
+      workerRef.current?.terminate();
+    };
+  }, []);
 
   const handleFile = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -30,34 +40,55 @@ function App() {
   );
 
   useEffect(() => {
-    if (!file) {
+    if (!file || !workerRef.current) {
       return;
     }
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const arrayBuffer = e.target?.result as ArrayBuffer;
-      const bytes = new Uint8Array(arrayBuffer);
-      try {
-        const decoded = decode(bytes);
+
+    const worker = workerRef.current;
+
+    const handleMessage = (event: MessageEvent<DecodeResponse>) => {
+      if (event.data.type === "success") {
+        const { result, blobUrl } = event.data;
         if (textAreaRef.current) {
-          textAreaRef.current.value = decoded;
+          // Only show preview for large files to avoid UI freeze
+          const PREVIEW_LIMIT = 100_000;
+          if (result.length > PREVIEW_LIMIT) {
+            textAreaRef.current.value =
+              result.slice(0, PREVIEW_LIMIT) +
+              `\n\n... (${(result.length / 1024 / 1024).toFixed(2)} MB total - download for full content)`;
+          } else {
+            textAreaRef.current.value = result;
+          }
         }
         if (downloadRef.current) {
-          const blob = new Blob([decoded], { type: "text/plain" });
-          const url = URL.createObjectURL(blob);
-          downloadRef.current.href = url;
+          downloadRef.current.href = blobUrl;
           downloadRef.current.download = file.name.replace(
             ".sii",
             "-decoded.sii",
           );
         }
-      } catch (error) {
-        if (textAreaRef.current && error instanceof Error) {
-          textAreaRef.current.value = error.toString();
+      } else if (event.data.type === "error") {
+        if (textAreaRef.current) {
+          textAreaRef.current.value = `Error: ${event.data.message}`;
         }
       }
     };
+
+    worker.addEventListener("message", handleMessage);
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const arrayBuffer = e.target?.result as ArrayBuffer;
+      // Transfer the buffer instead of copying
+      worker.postMessage({ type: "decode", buffer: arrayBuffer }, [
+        arrayBuffer,
+      ]);
+    };
     reader.readAsArrayBuffer(file);
+
+    return () => {
+      worker.removeEventListener("message", handleMessage);
+    };
   }, [file]);
 
   return (

--- a/web/src/decode.worker.ts
+++ b/web/src/decode.worker.ts
@@ -1,0 +1,34 @@
+import { decode } from "sii-decode-rs";
+
+export type DecodeRequest = {
+  type: "decode";
+  buffer: ArrayBuffer;
+};
+
+export type DecodeResponse =
+  | { type: "success"; result: string; blobUrl: string }
+  | { type: "error"; message: string };
+
+self.onmessage = (event: MessageEvent<DecodeRequest>) => {
+  if (event.data.type === "decode") {
+    try {
+      const bytes = new Uint8Array(event.data.buffer);
+      const result = decode(bytes);
+
+      // create blob URL in worker to avoid transferring large string back
+      const blob = new Blob([result], { type: "text/plain" });
+      const blobUrl = URL.createObjectURL(blob);
+      self.postMessage({
+        type: "success",
+        result,
+        blobUrl,
+      } satisfies DecodeResponse);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      self.postMessage({
+        type: "error",
+        message,
+      } satisfies DecodeResponse);
+    }
+  }
+};

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -7,6 +7,10 @@ import topLevelAwait from "vite-plugin-top-level-await";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), wasm(), topLevelAwait()],
+  worker: {
+    format: "es",
+    plugins: () => [wasm()],
+  },
   test: {
     setupFiles: [
       "tests/vitest-setup-dom.ts",


### PR DESCRIPTION
Fixes #12 

- Added decode.worker.ts for off-thread decoding
- Transfer ArrayBuffer to worker (zero-copy) instead of cloning
- Preview limit for textarea on large files to avoid render lag