### PR TITLE
Add web achievement tracker

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,10 +1,209 @@
 #root {
-  max-width: 1280px;
+  width: 100%;
+  max-width: 1180px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 24px;
+}
+
+.app-shell {
+  display: flex;
+  min-height: calc(100vh - 48px);
+  flex-direction: column;
+  gap: 20px;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.app-header h1,
+.panel h2,
+.achievement h3,
+.achievement p {
+  margin: 0;
+}
+
+.tabs {
+  display: inline-flex;
+  gap: 4px;
+  border: 1px solid #c8d0dc;
+  border-radius: 8px;
+  padding: 4px;
+  background: #f5f7fa;
+}
+
+.tabs button {
+  border: 0;
+  border-radius: 6px;
+  padding: 8px 12px;
+  background: transparent;
+  color: #263241;
+}
+
+.tabs button.active {
+  background: #1f2937;
+  color: #fff;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.file-row {
+  display: flex;
+}
+
+textarea {
+  box-sizing: border-box;
+  min-height: 420px;
+  width: 100%;
+  resize: vertical;
+  border: 1px solid #c8d0dc;
+  border-radius: 8px;
+  padding: 12px;
+  font:
+    13px/1.45 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.metric,
+.achievement {
+  border: 1px solid #d8dee8;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.metric {
+  display: flex;
+  min-height: 72px;
+  flex-direction: column;
+  justify-content: center;
+  padding: 12px;
+}
+
+.metric span,
+.progress-text,
+.achievement p,
+.evidence-list {
+  color: #5b6675;
+}
+
+.metric strong {
+  color: #152033;
+  font-size: 1.25rem;
+}
+
+.tracker-results,
+.achievements {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.achievement {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+}
+
+.achievement-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.status {
+  flex: none;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.status.complete {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status.in_progress {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+progress {
+  width: 100%;
+  height: 12px;
+}
+
+.evidence-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 8px 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.9rem;
+}
+
+.evidence-list li {
+  display: flex;
+  min-width: 0;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.evidence-list li span:last-child {
+  overflow: hidden;
+  color: #152033;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.error {
+  margin: 0;
+  color: #b91c1c;
 }
 
 .footer {
-  color: #888;
+  color: #697386;
+}
+
+@media (max-width: 640px) {
+  #root {
+    padding: 16px;
+  }
+
+  .app-header,
+  .achievement-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .tabs {
+    width: 100%;
+  }
+
+  .tabs button {
+    flex: 1;
+  }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,15 +1,55 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { ChangeEvent, ReactNode } from "react";
 import "./App.css";
 import DecodeWorker from "./decode.worker?worker";
 import type { DecodeResponse } from "./decode.worker";
 
+type Tab = "decode" | "tracker";
+
+type TrackerAnalysis = {
+  analytics: {
+    delivery_count: number;
+    total_distance_km: number;
+    total_revenue: number;
+    unique_cargos: string[];
+    unique_companies: string[];
+    job_type_breakdown: Record<string, number>;
+    brand_distance_km: Record<string, number>;
+    cargo_category_coverage: Record<string, number>;
+  };
+  achievements: Array<{
+    id: string;
+    display_name: string;
+    description: string;
+    status: "complete" | "in_progress";
+    progress: {
+      current: number;
+      target: number;
+      unit: string;
+    };
+    evidence: Array<{
+      label: string;
+      value: string;
+      complete: boolean;
+    }>;
+  }>;
+};
+
 function App() {
   const [file, setFile] = useState<File | null>(null);
+  const [trackerFile, setTrackerFile] = useState<File | null>(null);
+  const [activeTab, setActiveTab] = useState<Tab>(() =>
+    window.location.hash === "#tracker" ? "tracker" : "decode",
+  );
+  const [trackerState, setTrackerState] = useState<{
+    status: "idle" | "loading" | "success" | "error";
+    analysis: TrackerAnalysis | null;
+    error: string | null;
+  }>({ status: "idle", analysis: null, error: null });
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const downloadRef = useRef<HTMLAnchorElement>(null);
   const workerRef = useRef<Worker | null>(null);
 
-  // Initialize worker
   useEffect(() => {
     workerRef.current = new DecodeWorker();
     return () => {
@@ -17,27 +57,37 @@ function App() {
     };
   }, []);
 
-  const handleFile = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      if (!event.target.files || event.target.files.length === 0) {
-        return;
+  useEffect(() => {
+    const handleHashChange = () => {
+      setActiveTab(window.location.hash === "#tracker" ? "tracker" : "decode");
+    };
+    window.addEventListener("hashchange", handleHashChange);
+    return () => {
+      window.removeEventListener("hashchange", handleHashChange);
+    };
+  }, []);
+
+  const selectTab = useCallback((tab: Tab) => {
+    setActiveTab(tab);
+    window.location.hash = tab === "tracker" ? "tracker" : "decode";
+  }, []);
+
+  const handleFile = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    if (!event.target.files || event.target.files.length === 0) {
+      return;
+    }
+    const selectedFile = event.target.files[0];
+    if (textAreaRef.current) {
+      textAreaRef.current.value = "Decoding...";
+    }
+    if (downloadRef.current) {
+      if (downloadRef.current.href !== "#") {
+        URL.revokeObjectURL(downloadRef.current.href);
       }
-      const selectedFile = event.target.files[0];
-      if (textAreaRef.current) {
-        // Clear the text area
-        textAreaRef.current.value = "Decoding...";
-      }
-      if (downloadRef.current) {
-        // Clear the download link
-        if (downloadRef.current.href !== "#") {
-          URL.revokeObjectURL(downloadRef.current.href);
-        }
-        downloadRef.current.href = "#";
-      }
-      setFile(selectedFile);
-    },
-    [setFile, textAreaRef, downloadRef],
-  );
+      downloadRef.current.href = "#";
+    }
+    setFile(selectedFile);
+  }, []);
 
   useEffect(() => {
     if (!file || !workerRef.current) {
@@ -50,7 +100,6 @@ function App() {
       if (event.data.type === "success") {
         const { result, blobUrl } = event.data;
         if (textAreaRef.current) {
-          // Only show preview for large files to avoid UI freeze
           const PREVIEW_LIMIT = 100_000;
           if (result.length > PREVIEW_LIMIT) {
             textAreaRef.current.value =
@@ -79,7 +128,6 @@ function App() {
     const reader = new FileReader();
     reader.onload = (e) => {
       const arrayBuffer = e.target?.result as ArrayBuffer;
-      // Transfer the buffer instead of copying
       worker.postMessage({ type: "decode", buffer: arrayBuffer }, [
         arrayBuffer,
       ]);
@@ -91,33 +139,115 @@ function App() {
     };
   }, [file]);
 
+  const handleTrackerFile = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      if (!event.target.files || event.target.files.length === 0) {
+        return;
+      }
+      setTrackerState({ status: "loading", analysis: null, error: null });
+      setTrackerFile(event.target.files[0]);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!trackerFile || !workerRef.current) {
+      return;
+    }
+
+    const worker = workerRef.current;
+
+    const handleMessage = (event: MessageEvent<DecodeResponse>) => {
+      if (event.data.type === "analysis-success") {
+        try {
+          setTrackerState({
+            status: "success",
+            analysis: JSON.parse(event.data.result) as TrackerAnalysis,
+            error: null,
+          });
+        } catch {
+          setTrackerState({
+            status: "error",
+            analysis: null,
+            error: "Tracker output could not be read.",
+          });
+        }
+      } else if (event.data.type === "error") {
+        setTrackerState({
+          status: "error",
+          analysis: null,
+          error: event.data.message,
+        });
+      }
+    };
+
+    worker.addEventListener("message", handleMessage);
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const arrayBuffer = e.target?.result as ArrayBuffer;
+      worker.postMessage({ type: "analyze", buffer: arrayBuffer }, [
+        arrayBuffer,
+      ]);
+    };
+    reader.readAsArrayBuffer(trackerFile);
+
+    return () => {
+      worker.removeEventListener("message", handleMessage);
+    };
+  }, [trackerFile]);
+
   return (
-    <>
-      <h1>SII Decode</h1>
-      <p>Select a SII file to decode</p>
-      <div>
-        <input
-          type="file"
-          id="file"
-          data-testid="file-upload"
-          onChange={handleFile}
-        />
-      </div>
-      <br />
-      <textarea
-        id="output"
-        rows={20}
-        cols={50}
-        ref={textAreaRef}
-        data-testid="file-display"
-        spellCheck="false"
-        readOnly
-      />
-      <div>
-        <a href="#" ref={downloadRef} data-testid="file-download">
-          Download decoded file
-        </a>
-      </div>
+    <main className="app-shell">
+      <header className="app-header">
+        <h1>SII Decode</h1>
+        <nav className="tabs" aria-label="Primary">
+          <button
+            type="button"
+            className={activeTab === "decode" ? "active" : ""}
+            onClick={() => selectTab("decode")}
+          >
+            Decode
+          </button>
+          <button
+            type="button"
+            className={activeTab === "tracker" ? "active" : ""}
+            onClick={() => selectTab("tracker")}
+          >
+            ETS2 Tracker
+          </button>
+        </nav>
+      </header>
+
+      {activeTab === "decode" ? (
+        <section className="panel" aria-labelledby="decode-title">
+          <h2 id="decode-title">Decode</h2>
+          <div className="file-row">
+            <input
+              type="file"
+              id="file"
+              data-testid="file-upload"
+              onChange={handleFile}
+            />
+          </div>
+          <textarea
+            id="output"
+            rows={20}
+            ref={textAreaRef}
+            data-testid="file-display"
+            spellCheck="false"
+            readOnly
+          />
+          <div>
+            <a href="#" ref={downloadRef} data-testid="file-download">
+              Download decoded file
+            </a>
+          </div>
+        </section>
+      ) : (
+        <TrackerView state={trackerState} onFileChange={handleTrackerFile} />
+      )}
+
       <p className="footer">
         Your file is not uploaded to any server, it is decoded using your own
         browser.
@@ -130,8 +260,126 @@ function App() {
         </a>
         .
       </p>
-    </>
+    </main>
   );
+}
+
+function TrackerView({
+  state,
+  onFileChange,
+}: {
+  state: {
+    status: "idle" | "loading" | "success" | "error";
+    analysis: TrackerAnalysis | null;
+    error: string | null;
+  };
+  onFileChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}) {
+  return (
+    <section className="panel" aria-labelledby="tracker-title">
+      <h2 id="tracker-title">ETS2 Tracker</h2>
+      <div className="file-row">
+        <input
+          type="file"
+          id="tracker-file"
+          data-testid="tracker-file-upload"
+          onChange={onFileChange}
+        />
+      </div>
+
+      {state.status === "loading" ? (
+        <p data-testid="tracker-status">Analyzing save...</p>
+      ) : null}
+
+      {state.status === "error" ? (
+        <p className="error" data-testid="tracker-error">
+          Error: {state.error}
+        </p>
+      ) : null}
+
+      {state.status === "success" && state.analysis ? (
+        <div className="tracker-results" data-testid="tracker-results">
+          <AnalyticsSummary analysis={state.analysis} />
+          <AchievementList achievements={state.analysis.achievements} />
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function AnalyticsSummary({ analysis }: { analysis: TrackerAnalysis }) {
+  const analytics = analysis.analytics;
+  return (
+    <section className="summary-grid" aria-label="Analytics summary">
+      <Metric label="Deliveries" value={analytics.delivery_count} />
+      <Metric label="Distance" value={`${analytics.total_distance_km} km`} />
+      <Metric label="Revenue" value={formatCurrency(analytics.total_revenue)} />
+      <Metric label="Cargos" value={analytics.unique_cargos.length} />
+      <Metric label="Companies" value={analytics.unique_companies.length} />
+      <Metric
+        label="Job Types"
+        value={Object.keys(analytics.job_type_breakdown).length}
+      />
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="metric">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function AchievementList({
+  achievements,
+}: {
+  achievements: TrackerAnalysis["achievements"];
+}) {
+  return (
+    <section className="achievements" aria-label="Achievements">
+      {achievements.map((achievement) => (
+        <article className="achievement" key={achievement.id}>
+          <div className="achievement-heading">
+            <div>
+              <h3>{achievement.display_name}</h3>
+              <p>{achievement.description}</p>
+            </div>
+            <span className={`status ${achievement.status}`}>
+              {achievement.status === "complete" ? "Complete" : "In progress"}
+            </span>
+          </div>
+          <progress
+            value={achievement.progress.current}
+            max={achievement.progress.target}
+            aria-label={`${achievement.display_name} progress`}
+          />
+          <div className="progress-text">
+            {achievement.progress.current} / {achievement.progress.target}{" "}
+            {achievement.progress.unit}
+          </div>
+          <ul className="evidence-list">
+            {achievement.evidence.map((evidence) => (
+              <li key={evidence.label}>
+                <span>{evidence.label}</span>
+                <span>{evidence.value}</span>
+              </li>
+            ))}
+          </ul>
+        </article>
+      ))}
+    </section>
+  );
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "EUR",
+    maximumFractionDigits: 0,
+  }).format(value);
 }
 
 export default App;

--- a/web/src/decode.worker.ts
+++ b/web/src/decode.worker.ts
@@ -1,12 +1,18 @@
-import { decode } from "sii-decode-rs";
+import { analyze_ets2_save, decode } from "sii-decode-rs";
 
-export type DecodeRequest = {
-  type: "decode";
-  buffer: ArrayBuffer;
-};
+export type DecodeRequest =
+  | {
+      type: "decode";
+      buffer: ArrayBuffer;
+    }
+  | {
+      type: "analyze";
+      buffer: ArrayBuffer;
+    };
 
 export type DecodeResponse =
   | { type: "success"; result: string; blobUrl: string }
+  | { type: "analysis-success"; result: string }
   | { type: "error"; message: string };
 
 self.onmessage = (event: MessageEvent<DecodeRequest>) => {
@@ -22,6 +28,21 @@ self.onmessage = (event: MessageEvent<DecodeRequest>) => {
         type: "success",
         result,
         blobUrl,
+      } satisfies DecodeResponse);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      self.postMessage({
+        type: "error",
+        message,
+      } satisfies DecodeResponse);
+    }
+  } else if (event.data.type === "analyze") {
+    try {
+      const bytes = new Uint8Array(event.data.buffer);
+      const result = analyze_ets2_save(bytes);
+      self.postMessage({
+        type: "analysis-success",
+        result,
       } satisfies DecodeResponse);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -3,9 +3,8 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #152033;
+  background-color: #f4f6f8;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -15,28 +14,27 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: #1d4ed8;
   text-decoration: inherit;
 }
+
 a:hover {
-  color: #535bf2;
+  color: #1e40af;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
 
 h1 {
-  font-size: 3.2em;
+  font-size: 2.2rem;
   line-height: 1.1;
 }
 
 button {
-  border-radius: 8px;
+  border-radius: 6px;
   border: 1px solid transparent;
   padding: 0.6em 1.2em;
   font-size: 1em;
@@ -46,23 +44,12 @@ button {
   cursor: pointer;
   transition: border-color 0.25s;
 }
+
 button:hover {
   border-color: #646cff;
 }
+
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/web/tests/App.test.jsx
+++ b/web/tests/App.test.jsx
@@ -1,10 +1,9 @@
-import { test, expect, vi } from "vitest";
+import { test, expect, vi, beforeEach } from "vitest";
 import App from "../src/App";
 import "@testing-library/jest-dom/vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-// Mock the worker module
 vi.mock("../src/decode.worker?worker", () => {
   return {
     default: class MockWorker {
@@ -13,13 +12,11 @@ vi.mock("../src/decode.worker?worker", () => {
       onmessageerror = null;
 
       postMessage(data) {
-        // simulate async worker response
         setTimeout(() => {
           if (data.type === "decode") {
             const bytes = new Uint8Array(data.buffer);
             const text = new TextDecoder().decode(bytes);
 
-            // check if valid sii
             if (text.startsWith("SiiN")) {
               const blob = new Blob([text], { type: "text/plain" });
               const blobUrl = URL.createObjectURL(blob);
@@ -29,6 +26,58 @@ vi.mock("../src/decode.worker?worker", () => {
             } else {
               this.onmessage?.({
                 data: { type: "error", message: "Invalid SII file format" },
+              });
+            }
+          } else if (data.type === "analyze") {
+            const bytes = new Uint8Array(data.buffer);
+            const text = new TextDecoder().decode(bytes);
+
+            if (text.startsWith("BSII")) {
+              this.onmessage?.({
+                data: {
+                  type: "analysis-success",
+                  result: JSON.stringify({
+                    analytics: {
+                      delivery_count: 2,
+                      total_distance_km: 1844,
+                      total_revenue: 21760.5,
+                      unique_cargos: ["gravel", "canned_beef"],
+                      unique_companies: ["lkwlog", "stokes", "transinet"],
+                      job_type_breakdown: { cargo: 1, quick: 1 },
+                      brand_distance_km: { Mercedes: 362, Scania: 1482 },
+                      cargo_category_coverage: { bulk: 1, refrigerated: 1 },
+                    },
+                    achievements: [
+                      {
+                        id: "experience_beats_all",
+                        display_name: "Experience Beats All",
+                        description:
+                          "Complete deliveries with all trailer types.",
+                        status: "in_progress",
+                        progress: {
+                          current: 1,
+                          target: 8,
+                          unit: "categories",
+                        },
+                        evidence: [
+                          {
+                            label: "Bulk cargo",
+                            value: "gravel",
+                            complete: true,
+                          },
+                        ],
+                      },
+                    ],
+                  }),
+                },
+              });
+            } else {
+              this.onmessage?.({
+                data: {
+                  type: "error",
+                  message:
+                    "Structured BSII analysis requires a binary BSII file",
+                },
               });
             }
           }
@@ -52,32 +101,33 @@ vi.mock("../src/decode.worker?worker", () => {
   };
 });
 
+beforeEach(() => {
+  window.location.hash = "";
+});
+
 test("App can render", () => {
   render(<App />);
-  // Has a file upload box
+
   expect(screen.getByTestId("file-upload")).toBeInTheDocument();
 
-  // Has a download button
   const downloadButton = screen.getByTestId("file-download");
   expect(downloadButton).toBeInTheDocument();
   expect(downloadButton).toHaveAttribute("href", "#");
 
-  // Has a read only text area for displaying
   const textArea = screen.getByTestId("file-display");
   expect(textArea).toBeInTheDocument();
   expect(textArea).toHaveAttribute("readonly");
-  // Initially empty
   expect(textArea).toHaveValue("");
 });
 
 test("App can decode", async () => {
+  window.location.hash = "#decode";
   render(<App />);
   const fileUploadBox = screen.getByTestId("file-upload");
   const file = new File(["SiiN"], "test.sii");
-  userEvent.upload(fileUploadBox, file);
+  await userEvent.upload(fileUploadBox, file);
 
   const textArea = screen.getByTestId("file-display");
-  // Wait for the text area to be updated
   await waitFor(() => {
     expect(textArea).toHaveValue("SiiN");
 
@@ -87,17 +137,63 @@ test("App can decode", async () => {
 });
 
 test("App can display error", async () => {
+  window.location.hash = "#decode";
   render(<App />);
   const fileUploadBox = screen.getByTestId("file-upload");
   const file = new File(["invalid"], "test.sii");
-  userEvent.upload(fileUploadBox, file);
+  await userEvent.upload(fileUploadBox, file);
 
   const textArea = screen.getByTestId("file-display");
-  // Wait for the text area to be updated
   await waitFor(() => {
     expect(textArea).toHaveDisplayValue(/Error:/);
 
     const downloadButton = screen.getByTestId("file-download");
     expect(downloadButton).toHaveAttribute("href", "#");
+  });
+});
+
+test("Tracker can render analysis", async () => {
+  window.location.hash = "#tracker";
+  render(<App />);
+
+  const fileUploadBox = screen.getByTestId("tracker-file-upload");
+  const file = new File(["BSII"], "save.sii");
+  await userEvent.upload(fileUploadBox, file);
+
+  await waitFor(() => {
+    expect(screen.getByTestId("tracker-results")).toBeInTheDocument();
+  });
+  expect(screen.getByText("Experience Beats All")).toBeInTheDocument();
+  expect(screen.getByText("1 / 8 categories")).toBeInTheDocument();
+  const deliveries = screen.getByText("Deliveries").closest(".metric");
+  expect(deliveries).not.toBeNull();
+  expect(within(deliveries).getByText("2")).toBeInTheDocument();
+});
+
+test("Tracker can display unsupported-format error", async () => {
+  window.location.hash = "#tracker";
+  render(<App />);
+
+  const fileUploadBox = screen.getByTestId("tracker-file-upload");
+  const file = new File(["SiiN"], "save.sii");
+  await userEvent.upload(fileUploadBox, file);
+
+  await waitFor(() => {
+    expect(screen.getByTestId("tracker-error")).toHaveTextContent(
+      /Structured BSII analysis/,
+    );
+  });
+});
+
+test("Tracker can display worker error", async () => {
+  window.location.hash = "#tracker";
+  render(<App />);
+
+  const fileUploadBox = screen.getByTestId("tracker-file-upload");
+  const file = new File(["invalid"], "save.sii");
+  await userEvent.upload(fileUploadBox, file);
+
+  await waitFor(() => {
+    expect(screen.getByTestId("tracker-error")).toHaveTextContent(/Error:/);
   });
 });


### PR DESCRIPTION
## Summary
- add Decode and ETS2 Tracker tabs with hash routing
- keep decode and ETS2 analysis work inside the worker
- show tracker analytics, achievement progress, evidence, and errors
- preserve decode preview limiting and full decoded download

## Verification
- yarn prettier -w src/App.tsx src/App.css src/index.css src/decode.worker.ts tests/App.test.jsx
- yarn lint
- yarn test
- wasm-pack build --all-features
- yarn install --force
- yarn build