### PR TITLE
Scope web worker error responses

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -116,7 +116,7 @@ function App() {
             "-decoded.sii",
           );
         }
-      } else if (event.data.type === "error") {
+      } else if (event.data.type === "decode-error") {
         if (textAreaRef.current) {
           textAreaRef.current.value = `Error: ${event.data.message}`;
         }
@@ -172,7 +172,7 @@ function App() {
             error: "Tracker output could not be read.",
           });
         }
-      } else if (event.data.type === "error") {
+      } else if (event.data.type === "analysis-error") {
         setTrackerState({
           status: "error",
           analysis: null,

--- a/web/src/decode.worker.ts
+++ b/web/src/decode.worker.ts
@@ -13,7 +13,8 @@ export type DecodeRequest =
 export type DecodeResponse =
   | { type: "success"; result: string; blobUrl: string }
   | { type: "analysis-success"; result: string }
-  | { type: "error"; message: string };
+  | { type: "decode-error"; message: string }
+  | { type: "analysis-error"; message: string };
 
 self.onmessage = (event: MessageEvent<DecodeRequest>) => {
   if (event.data.type === "decode") {
@@ -32,7 +33,7 @@ self.onmessage = (event: MessageEvent<DecodeRequest>) => {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       self.postMessage({
-        type: "error",
+        type: "decode-error",
         message,
       } satisfies DecodeResponse);
     }
@@ -47,7 +48,7 @@ self.onmessage = (event: MessageEvent<DecodeRequest>) => {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       self.postMessage({
-        type: "error",
+        type: "analysis-error",
         message,
       } satisfies DecodeResponse);
     }

--- a/web/tests/App.test.jsx
+++ b/web/tests/App.test.jsx
@@ -26,7 +26,10 @@ vi.mock("../src/decode.worker?worker", () => {
               });
             } else {
               this.dispatchMessage({
-                data: { type: "error", message: "Invalid SII file format" },
+                data: {
+                  type: "decode-error",
+                  message: "Invalid SII file format",
+                },
               });
             }
           } else if (data.type === "analyze") {
@@ -75,7 +78,7 @@ vi.mock("../src/decode.worker?worker", () => {
             } else {
               this.dispatchMessage({
                 data: {
-                  type: "error",
+                  type: "analysis-error",
                   message:
                     "Structured BSII analysis requires a binary BSII file",
                 },
@@ -202,4 +205,56 @@ test("Tracker can display worker error", async () => {
   await waitFor(() => {
     expect(screen.getByTestId("tracker-error")).toHaveTextContent(/Error:/);
   });
+});
+
+test("Decode errors do not overwrite tracker state after both tabs are used", async () => {
+  window.location.hash = "#tracker";
+  render(<App />);
+
+  const trackerUpload = screen.getByTestId("tracker-file-upload");
+  await userEvent.upload(trackerUpload, new File(["BSII"], "save.sii"));
+
+  await waitFor(() => {
+    expect(screen.getByTestId("tracker-results")).toBeInTheDocument();
+  });
+
+  await userEvent.click(screen.getByRole("button", { name: "Decode" }));
+  await userEvent.upload(
+    screen.getByTestId("file-upload"),
+    new File(["invalid"], "bad.sii"),
+  );
+
+  await waitFor(() => {
+    expect(screen.getByTestId("file-display")).toHaveDisplayValue(/Error:/);
+  });
+
+  await userEvent.click(screen.getByRole("button", { name: "ETS2 Tracker" }));
+
+  expect(screen.getByTestId("tracker-results")).toBeInTheDocument();
+  expect(screen.queryByTestId("tracker-error")).not.toBeInTheDocument();
+});
+
+test("Tracker errors do not render in decode output after both tabs are used", async () => {
+  window.location.hash = "#decode";
+  render(<App />);
+
+  await userEvent.upload(
+    screen.getByTestId("file-upload"),
+    new File(["SiiN"], "test.sii"),
+  );
+
+  await waitFor(() => {
+    expect(screen.getByTestId("file-display")).toHaveDisplayValue("SiiN");
+  });
+
+  await userEvent.click(screen.getByRole("button", { name: "ETS2 Tracker" }));
+  await userEvent.upload(
+    screen.getByTestId("tracker-file-upload"),
+    new File(["invalid"], "save.sii"),
+  );
+  await userEvent.click(screen.getByRole("button", { name: "Decode" }));
+
+  await new Promise((resolve) => setTimeout(resolve, 30));
+
+  expect(screen.getByTestId("file-display")).not.toHaveDisplayValue(/Error:/);
 });


### PR DESCRIPTION
## Summary
- split worker error responses into decode-error and analysis-error
- keep decode and tracker listeners scoped to their own worker failures
- add regression coverage for decode/tracker cross-talk after both tabs have been used

## Verification
- yarn prettier -w src/App.tsx src/decode.worker.ts tests/App.test.jsx
- yarn test
- yarn lint
- yarn build

Replacement for #30 after stacked base #29 merged.