### PR TITLE
Track more ETS2 delivery achievements

### DIFF
--- a/src/ets2/achievements.rs
+++ b/src/ets2/achievements.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::ets2::generated::cargo_metadata::CARGOS;
-use crate::ets2::save::{cargo_id, truck_brand, SaveGame};
+use crate::ets2::save::{cargo_id, company_id, truck_brand, DeliveryLogEntry, SaveGame};
 use crate::ets2::CargoMetadata;
 
 pub const EXPERIENCE_BEATS_ALL_CATEGORIES: [&str; 8] = [
@@ -18,6 +18,12 @@ pub const EXPERIENCE_BEATS_ALL_CATEGORIES: [&str; 8] = [
 const TEST_DRIVE_LIMITED_TARGET_BRANDS: u32 = 5;
 const TEST_DRIVE_LIMITED_TARGET_DISTANCE_KM: u64 = 999;
 const OWNED_TRUCK_JOB_TYPES: [&str; 4] = ["cargo", "external", "compn", "on_compn"];
+const ALL_IS_POSSIBLE_TARGET_CARGOS: u32 = 30;
+const RELIABLE_CONTRACTOR_TARGET_COMPANIES: u32 = 15;
+const LONG_HAULER_TARGET_DISTANCE_KM: u32 = 2000;
+const PROFIT_HUNTER_TARGET_REVENUE: f64 = 130_000.0;
+const PROFIT_HUNTER_TARGET_DISTANCE_KM: u32 = 2200;
+const SUMMARY_EVIDENCE_LIMIT: usize = 30;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct AchievementRegistry {
@@ -56,7 +62,14 @@ pub struct AchievementEvidence {
 
 pub fn evaluate_achievements(save: &SaveGame) -> AchievementRegistry {
     AchievementRegistry {
-        achievements: vec![experience_beats_all(save), test_drive_limited(save)],
+        achievements: vec![
+            experience_beats_all(save),
+            test_drive_limited(save),
+            all_is_possible(save),
+            reliable_contractor(save),
+            long_hauler(save),
+            profit_hunter(save),
+        ],
     }
 }
 
@@ -144,6 +157,143 @@ fn test_drive_limited(save: &SaveGame) -> Achievement {
     }
 }
 
+fn all_is_possible(save: &SaveGame) -> Achievement {
+    let cargos = save
+        .delivery_log
+        .unique_cargos()
+        .into_iter()
+        .filter(|cargo| !cargo.is_empty())
+        .collect::<BTreeSet<_>>();
+    let current = cargos.len() as u32;
+
+    Achievement {
+        id: "all_is_possible",
+        display_name: "All Is Possible",
+        description: "Take and complete jobs with at least 30 different cargoes.",
+        status: status_from_progress(current, ALL_IS_POSSIBLE_TARGET_CARGOS),
+        progress: AchievementProgress {
+            current,
+            target: ALL_IS_POSSIBLE_TARGET_CARGOS,
+            unit: "cargoes",
+        },
+        evidence: vec![AchievementEvidence {
+            label: "Completed cargoes".to_string(),
+            value: summarize_set(&cargos, SUMMARY_EVIDENCE_LIMIT),
+            complete: current >= ALL_IS_POSSIBLE_TARGET_CARGOS,
+        }],
+    }
+}
+
+fn reliable_contractor(save: &SaveGame) -> Achievement {
+    let companies = save
+        .delivery_log
+        .entries
+        .iter()
+        .flat_map(|entry| {
+            [
+                company_id(&entry.source_company).to_string(),
+                company_id(&entry.destination_company).to_string(),
+            ]
+        })
+        .filter(|company| !company.is_empty())
+        .collect::<BTreeSet<_>>();
+    let current = companies.len() as u32;
+
+    Achievement {
+        id: "reliable_contractor",
+        display_name: "Reliable Contractor",
+        description: "Perform jobs for at least 15 different companies in the game.",
+        status: status_from_progress(current, RELIABLE_CONTRACTOR_TARGET_COMPANIES),
+        progress: AchievementProgress {
+            current,
+            target: RELIABLE_CONTRACTOR_TARGET_COMPANIES,
+            unit: "companies",
+        },
+        evidence: vec![AchievementEvidence {
+            label: "Companies".to_string(),
+            value: summarize_set(&companies, SUMMARY_EVIDENCE_LIMIT),
+            complete: current >= RELIABLE_CONTRACTOR_TARGET_COMPANIES,
+        }],
+    }
+}
+
+fn long_hauler(save: &SaveGame) -> Achievement {
+    let longest = save
+        .delivery_log
+        .entries
+        .iter()
+        .max_by_key(|entry| entry.distance_km);
+    let current = longest.map_or(0, |entry| entry.distance_km);
+    let complete = current > LONG_HAULER_TARGET_DISTANCE_KM;
+
+    Achievement {
+        id: "long_hauler",
+        display_name: "Long Hauler",
+        description: "Complete a delivery that was greater than 2,000 km.",
+        status: if complete {
+            AchievementStatus::Complete
+        } else {
+            AchievementStatus::InProgress
+        },
+        progress: AchievementProgress {
+            current,
+            target: LONG_HAULER_TARGET_DISTANCE_KM,
+            unit: "km",
+        },
+        evidence: vec![AchievementEvidence {
+            label: "Longest delivery".to_string(),
+            value: longest
+                .map(delivery_summary)
+                .unwrap_or_else(|| "missing".to_string()),
+            complete,
+        }],
+    }
+}
+
+fn profit_hunter(save: &SaveGame) -> Achievement {
+    let qualifying = save
+        .delivery_log
+        .entries
+        .iter()
+        .filter(|entry| is_profit_hunter_delivery(entry))
+        .max_by(|left, right| left.revenue.total_cmp(&right.revenue));
+    let evidence_entry = qualifying.or_else(|| {
+        save.delivery_log
+            .entries
+            .iter()
+            .max_by(|left, right| left.revenue.total_cmp(&right.revenue))
+    });
+    let current = evidence_entry.map_or(0, profit_hunter_criteria_met);
+    let complete = qualifying.is_some();
+
+    Achievement {
+        id: "profit_hunter",
+        display_name: "Profit Hunter",
+        description: "Complete one job worth over 130,000 EUR and at least 2,200 km.",
+        status: if complete {
+            AchievementStatus::Complete
+        } else {
+            AchievementStatus::InProgress
+        },
+        progress: AchievementProgress {
+            current,
+            target: 2,
+            unit: "requirements",
+        },
+        evidence: vec![AchievementEvidence {
+            label: if complete {
+                "Qualifying job".to_string()
+            } else {
+                "Best revenue job".to_string()
+            },
+            value: evidence_entry
+                .map(delivery_summary)
+                .unwrap_or_else(|| "missing".to_string()),
+            complete,
+        }],
+    }
+}
+
 fn status_from_progress(current: u32, target: u32) -> AchievementStatus {
     if current >= target {
         AchievementStatus::Complete
@@ -214,6 +364,45 @@ fn display_truck_brand(brand: &str) -> &str {
     }
 }
 
+fn summarize_set(values: &BTreeSet<String>, limit: usize) -> String {
+    if values.is_empty() {
+        return "missing".to_string();
+    }
+
+    let mut summary = values.iter().take(limit).cloned().collect::<Vec<_>>();
+    if values.len() > limit {
+        summary.push(format!("+{} more", values.len() - limit));
+    }
+    summary.join(", ")
+}
+
+fn delivery_summary(entry: &DeliveryLogEntry) -> String {
+    format!(
+        "{}, {} km, {}",
+        cargo_id(&entry.cargo),
+        entry.distance_km,
+        format_revenue(entry.revenue)
+    )
+}
+
+fn format_revenue(revenue: f64) -> String {
+    if revenue.fract() == 0.0 {
+        format!("{revenue:.0} EUR")
+    } else {
+        format!("{revenue:.2} EUR")
+    }
+}
+
+fn is_profit_hunter_delivery(entry: &DeliveryLogEntry) -> bool {
+    entry.revenue > PROFIT_HUNTER_TARGET_REVENUE
+        && entry.distance_km >= PROFIT_HUNTER_TARGET_DISTANCE_KM
+}
+
+fn profit_hunter_criteria_met(entry: &DeliveryLogEntry) -> u32 {
+    u32::from(entry.revenue > PROFIT_HUNTER_TARGET_REVENUE)
+        + u32::from(entry.distance_km >= PROFIT_HUNTER_TARGET_DISTANCE_KM)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -277,6 +466,101 @@ mod tests {
     }
 
     #[test]
+    fn evaluates_all_is_possible() {
+        let mut entries = (0..30)
+            .map(|index| {
+                entry(
+                    &format!("cargo.cargo_{index}"),
+                    200,
+                    "vehicle.man.tgx",
+                    "quick",
+                )
+            })
+            .collect::<Vec<_>>();
+        entries.push(entry("", 200, "vehicle.man.tgx", "quick"));
+        let save = save_with_entries(entries);
+
+        let achievement = achievement_by_id(&save, "all_is_possible");
+
+        assert_eq!(achievement.status, AchievementStatus::Complete);
+        assert_eq!(achievement.progress.current, 30);
+        assert_eq!(achievement.progress.target, 30);
+        assert!(achievement.evidence[0].complete);
+    }
+
+    #[test]
+    fn evaluates_reliable_contractor() {
+        let mut entries = (0..8)
+            .map(|index| DeliveryLogEntry {
+                source_company: format!("company.volatile.source_{index}.amsterdam"),
+                destination_company: format!("company.volatile.destination_{index}.rotterdam"),
+                ..entry("cargo.gravel", 200, "vehicle.man.tgx", "quick")
+            })
+            .collect::<Vec<_>>();
+        entries.push(DeliveryLogEntry {
+            source_company: "".to_string(),
+            destination_company: "company.volatile.source_0.amsterdam".to_string(),
+            ..entry("cargo.gravel", 200, "vehicle.man.tgx", "quick")
+        });
+        let save = save_with_entries(entries);
+
+        let achievement = achievement_by_id(&save, "reliable_contractor");
+
+        assert_eq!(achievement.status, AchievementStatus::Complete);
+        assert_eq!(achievement.progress.current, 16);
+        assert_eq!(achievement.progress.target, 15);
+        assert!(achievement.evidence[0].value.contains("source_0"));
+    }
+
+    #[test]
+    fn evaluates_long_hauler() {
+        let save = save_with_entries(vec![
+            entry("cargo.gravel", 2000, "vehicle.man.tgx", "quick"),
+            entry("cargo.canned_beef", 2001, "vehicle.scania.r", "quick"),
+        ]);
+
+        let achievement = achievement_by_id(&save, "long_hauler");
+
+        assert_eq!(achievement.status, AchievementStatus::Complete);
+        assert_eq!(achievement.progress.current, 2001);
+        assert_eq!(achievement.progress.target, 2000);
+        assert_eq!(
+            achievement.evidence[0].value,
+            "canned_beef, 2001 km, 1000 EUR"
+        );
+    }
+
+    #[test]
+    fn evaluates_profit_hunter_as_single_qualifying_job() {
+        let save = save_with_entries(vec![
+            revenue_entry("cargo.gravel", 2300, 130_001.0),
+            revenue_entry("cargo.canned_beef", 3000, 100_000.0),
+            revenue_entry("cargo.bricks", 1000, 180_000.0),
+        ]);
+
+        let achievement = achievement_by_id(&save, "profit_hunter");
+
+        assert_eq!(achievement.status, AchievementStatus::Complete);
+        assert_eq!(achievement.progress.current, 2);
+        assert_eq!(achievement.evidence[0].label, "Qualifying job");
+        assert_eq!(achievement.evidence[0].value, "gravel, 2300 km, 130001 EUR");
+    }
+
+    #[test]
+    fn profit_hunter_stays_in_progress_when_requirements_are_split_across_jobs() {
+        let save = save_with_entries(vec![
+            revenue_entry("cargo.canned_beef", 3000, 100_000.0),
+            revenue_entry("cargo.bricks", 1000, 180_000.0),
+        ]);
+
+        let achievement = achievement_by_id(&save, "profit_hunter");
+
+        assert_eq!(achievement.status, AchievementStatus::InProgress);
+        assert_eq!(achievement.progress.current, 1);
+        assert_eq!(achievement.evidence[0].label, "Best revenue job");
+    }
+
+    #[test]
     fn owned_truck_job_type_filter_matches_v1_rules() {
         for job_type in ["cargo", "external", "compn", "on_compn"] {
             assert!(is_owned_truck_job_type(job_type));
@@ -316,5 +600,20 @@ mod tests {
             truck: truck.to_string(),
             job_type: job_type.to_string(),
         }
+    }
+
+    fn revenue_entry(cargo: &str, distance_km: u32, revenue: f64) -> DeliveryLogEntry {
+        DeliveryLogEntry {
+            revenue,
+            ..entry(cargo, distance_km, "vehicle.man.tgx", "quick")
+        }
+    }
+
+    fn achievement_by_id(save: &SaveGame, id: &str) -> Achievement {
+        evaluate_achievements(save)
+            .achievements
+            .into_iter()
+            .find(|achievement| achievement.id == id)
+            .unwrap()
     }
 }

--- a/src/ets2/save.rs
+++ b/src/ets2/save.rs
@@ -8,14 +8,16 @@ pub const COMPANY_PREFIX: &str = "company.volatile.";
 pub const CARGO_PREFIX: &str = "cargo.";
 pub const VEHICLE_PREFIX: &str = "vehicle.";
 
+// Delivery log params are reverse engineered by the community:
+// https://forum.scssoft.com/viewtopic.php?start=10&t=317674
 const SOURCE_COMPANY_PARAM: usize = 1;
 const DESTINATION_COMPANY_PARAM: usize = 2;
 const CARGO_PARAM: usize = 3;
-const DISTANCE_PARAM: usize = 5;
+const REVENUE_PARAM: usize = 5;
+const DISTANCE_PARAM: usize = 6;
 const TRUCK_PARAM: usize = 16;
 const JOB_TYPE_PARAM: usize = 18;
-const REVENUE_PARAM: usize = 22;
-const MIN_PARAMS_LEN: usize = REVENUE_PARAM + 1;
+const MIN_PARAMS_LEN: usize = JOB_TYPE_PARAM + 1;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SaveGame {
@@ -330,30 +332,32 @@ mod tests {
             "company.volatile.stokes.amsterdam",
             "cargo.gravel",
             "16",
+            "16930.000",
             "362",
-            "0",
             "0.000",
             "295",
             "0",
             "0",
             "1",
             "1",
-            "362",
+            "16930",
             "0",
             "600",
             "vehicle.mercedes.actros",
-            "1",
+            "362",
             "quick",
             "",
             "",
             "0",
-            "16930.000",
+            "25000.000",
         ];
         let entry = DeliveryLogEntry::from_params(&params).unwrap();
 
         assert_eq!(entry.source_company, "company.volatile.lkwlog.amsterdam");
         assert_eq!(company_id(&entry.source_company), "lkwlog");
         assert_eq!(cargo_id(&entry.cargo), "gravel");
+        assert_eq!(entry.distance_km, 362);
+        assert_eq!(entry.revenue, 16930.0);
         assert_eq!(truck_brand(&entry.truck), "mercedes");
         assert_eq!(entry.job_type, "quick");
     }
@@ -453,24 +457,24 @@ mod tests {
             "company.volatile.stokes.amsterdam",
             cargo,
             "16",
+            revenue,
             distance,
-            "0",
             "0.000",
             "295",
             "0",
             "0",
             "1",
             "1",
-            distance,
+            revenue,
             "0",
             "600",
             truck,
-            "1",
+            distance,
             job_type,
             "",
             "",
             "0",
-            revenue,
+            "25000.000",
         ]
     }
 


### PR DESCRIPTION
## Summary
- add delivery-log achievement evaluators for All Is Possible, Reliable Contractor, Long Hauler, and Profit Hunter
- correct ETS2 delivery_log_entry param mapping for revenue and distance using the community reverse-engineering reference
- filter empty cargo/company IDs from progress evidence summaries

## Self-review
- No blocking findings found.
- Main risk reviewed: modern 24-param delivery log entries store actual revenue in params[5], actual distance in params[6], and cargo mass in params[22]; tests now assert the corrected parser mapping.
- Browser/wasm cache issue was verified locally by rebuilding pkg and checking the copied web package returns 8/8 categories.

## Validation
- cargo test --all-features
- cargo run -- --ets2-achievements /Users/fangyi/Downloads/encrypted_game.sii
- git diff --check